### PR TITLE
Fix routes, redirects, and basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Option | Type | Default | Description
 `channel` | string | `null` | The default channel that messages will be sent to, otherwise defaults to what's set on the Slack's incoming webhook
 `region` | string | `'eu'` | Platform.sh region where the project is hosted. This is used to build the links to the project. 
 `commit_limit` | int | `10` | The number of commits from the payload to include in the Slack message 
-`routes` | bool | `false` | Whether to show project's routes on every slack message. If false, it will be shown only when you branch
+`routes` | bool | `false` | Whether to show project's routes on every slack message. If false, it will be shown only when you branch.
+`redirects` | bool | `false` | Whether to include project's redirects with routes on every Slack message. If false, redirects will be shown only when you branch.
+`basic_auth` | bool | `false` | Whether to show project environment's HTTP Authentication username and password in Slack message.  WARNING: If true, potentially sensitive data passwords will be sent in the clear to your Slack channel.
 `configurations` | bool | `false` | Whether to show project's configurations on every slack message. If false, it will be shown only for master when you push, merge or have a subscription plan update.
 `attachment_color` | string | `'#e8e8e8'` | RGB color for Slack attachment.
 `project` | string | `null` | If present, it will be used as the project name instead of the ID. Project name is misisng in Platform.sh's payload.

--- a/src/Platformsh2Slack.php
+++ b/src/Platformsh2Slack.php
@@ -264,6 +264,12 @@ class Platformsh2Slack {
 
       default:
         $this->slack_text = "$name triggerred an unhandled webhook `{$platformsh->type}` to branch `$branch` of <$project_url|$project>";
+        $this->slack->attach(array(
+          'title' => 'Description',
+          'color' => $this->config['attachment_color'],
+          'text' => strip_tags($platformsh->description),
+          'fallback' => strip_tags($platformsh->description),
+        ));
         if ($this->config['debug']) {
           $debug = true;
           $this->slack->attach(array(

--- a/src/Platformsh2Slack.php
+++ b/src/Platformsh2Slack.php
@@ -171,6 +171,33 @@ class Platformsh2Slack {
         $show_basic_auth = true;
         break;
 
+      case 'environment.access.add':
+        $this->slack_text = "$name added {$platformsh->payload->access->display_name} to `$branch` of <$project_url|$project>";
+        break;
+
+      case 'environment.access.remove':
+        $this->slack_text = "$name removed {$platformsh->payload->access->display_name} from `$branch` of <$project_url|$project>";
+        break;
+
+      case 'environment.redeploy':
+        $this->slack_text = "$name redeployed environment `$branch` of <$project_url|$project>";
+        break;
+
+      case 'environment.synchronize':
+        $parent = $platformsh->parameters->from;
+        $child = $platformsh->parameters->into;
+        if ($platformsh->parameters->synchronize_code) {
+          $payload[] = '*code*';
+        }
+        if ($platformsh->parameters->synchronize_data) {
+          $payload[] = '*data & files*';
+        }
+
+        $payload = implode(', ', $payload);
+
+        $this->slack_text = "$name synchronized $payload from `$parent` into `$child` environment of <$project_url|$project>";
+        break;
+
       case 'environment.push':
         $this->slack_text = "$name pushed $commits_count_str to branch `$branch` of <$project_url|$project>";
         if ($branch == 'master') {

--- a/src/Platformsh2Slack.php
+++ b/src/Platformsh2Slack.php
@@ -378,6 +378,15 @@ class Platformsh2Slack {
           ));
         }
       }
+
+      if ($platformsh->result != 'success') {
+        $this->slack->attach(array(
+          'title' => 'Build log',
+          'text' => $platformsh->log,
+          'fallback' => $platformsh->log,
+          'color' => 'danger',
+        ));
+      }
     }
   }
 


### PR DESCRIPTION
* Fixes regex to detect Environment configuration optional colon (:)  which it seems they may have modified the output string for Environment Config info since the original regular expression was created.

* Adds support for `environment.activate` webhook. 
[platformsh2slack.environment.activate.1537830200.json.txt](https://github.com/hanoii/platformsh2slack/files/2414226/platformsh2slack.environment.activate.1537830200.json.txt)
<img width="814" alt="screen shot 2018-09-25 at 2 16 54 am" src="https://user-images.githubusercontent.com/243532/45999771-44ea3200-c06c-11e8-8246-f3ecfb823b6b.png">

* Adds support for `environment.update.http_access` webhook.
[platformsh2slack.environment.update.http_access.1537830227.json.txt](https://github.com/hanoii/platformsh2slack/files/2414227/platformsh2slack.environment.update.http_access.1537830227.json.txt)

<img width="812" alt="screen shot 2018-09-25 at 2 26 51 am" src="https://user-images.githubusercontent.com/243532/45999798-56333e80-c06c-11e8-8d76-2ba467839882.png">

* Adds support for `environment.access.add`, `environment.access.remove`,  `environment.redeploy` and `environment.syncrhonize`. (We're finding these particularly useful for sharing the HTTP Auth info in Slack which we use extensively on all non-master environments).

* Improves display of Routes and Redirects based on payload data instead of preg_match.

* Adds option to exclude redirects from some messages. Note: environment.activate and environment.branch webhooks will always show redirects.