### PR TITLE
Support 'environment.backup.delete' webhook type

### DIFF
--- a/src/Platformsh2Slack.php
+++ b/src/Platformsh2Slack.php
@@ -260,6 +260,10 @@ class Platformsh2Slack {
         $this->slack_text = "$name created the snapshot `{$platformsh->payload->backup_name}` from `$branch` of $project_string";
         break;
 
+      case 'environment.backup.delete':
+        $this->slack_text = "$name deleted the snapshot `{$platformsh->payload->backup_name}` from `$branch` of $project_string";
+        break;
+
       case 'environment.deactivate':
         $this->slack_text = "$name deactivated the environment `$branch` of $project_string";
         break;


### PR DESCRIPTION
Adds support for the `environment.backup.delete` webhook... which all of a sudden has started happening like mad on our projects.  Apparently Platform.sh waits a year or two before cleaning up a bunch of old outdated snapshots.