### PR TITLE
Fallback project parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Option | Type | Default | Description
 `basic_auth` | bool | `false` | Whether to show project environment's HTTP Authentication username and password in Slack message.  WARNING: If true, potentially sensitive data passwords will be sent in the clear to your Slack channel.
 `configurations` | bool | `false` | Whether to show project's configurations on every slack message. If false, it will be shown only for master when you push, merge or have a subscription plan update.
 `attachment_color` | string | `'#e8e8e8'` | RGB color for Slack attachment.
-`project` | string | `null` | If present, it will be used as the project name instead of the default string. Project name is misisng in Platform.sh's payload.
+`project` | string | `null` | If present, it will be used as the project title instead of the default.
 `project_url` | string | `null` | If present, the project name will be used as a link to this URL on Slack notifications. Environment branch will be appended automatically to the URL.
 `debug` | string | `null` | An optional path where posssible unhandled webhooks JSON can be saved. This is useful if you want to send over the json for me to add support for it.
 `debug_all` | boolean | `false` | If `debug` is set, it saves the JSON of every webhook sent, not only the unhandled ones.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Option | Type | Default | Description
 `configurations` | bool | `false` | Whether to show project's configurations on every slack message. If false, it will be shown only for master when you push, merge or have a subscription plan update.
 `attachment_color` | string | `'#e8e8e8'` | RGB color for Slack attachment.
 `project` | string | `null` | If present, it will be used as the project title instead of the default.
-`project_url` | string | `null` | If present, the project name will be used as a link to this URL on Slack notifications. Environment branch will be appended automatically to the URL.
+`project_url` | string | `null` | If present, the project title will link to this URL instead of the default for Slack notifications. Environment branch will be appended automatically to the URL. If empty, the default project link will be used: `https://console.platform.sh/project/{project_id}`.
 `debug` | string | `null` | An optional path where posssible unhandled webhooks JSON can be saved. This is useful if you want to send over the json for me to add support for it.
 `debug_all` | boolean | `false` | If `debug` is set, it saves the JSON of every webhook sent, not only the unhandled ones.
 `active` | boolean | `false` | If `active` is set, only webhooks of active environments will be sent to platform. Useful for some external integrations.

--- a/src/Platformsh2Slack.php
+++ b/src/Platformsh2Slack.php
@@ -145,6 +145,10 @@ class Platformsh2Slack {
       $url .= "/$branch";
       $project_string = "<$url|$project_string>";
     }
+    else {
+      $url = "https://console.platform.sh/project/$project_id/$branch";
+      $project_string = "<$url|$project_string>";
+    }
 
     // Commits
     if (!empty($platformsh->payload->commits_count)) {

--- a/src/Platformsh2Slack.php
+++ b/src/Platformsh2Slack.php
@@ -134,6 +134,9 @@ class Platformsh2Slack {
     // Project string identifier
     //
     $project_string = 'Platform.sh';
+    if (!empty($platformsh->payload->project->title)) {
+      $project_string = $platformsh->payload->project->title;
+    }
     if ($this->config['project']) {
       $project_string = $this->config['project'];
     }


### PR DESCRIPTION
Two things going on in this PR:

1. For the `project` parameter, the project title is now provided in the platform.sh JSON data under  `payload > project > title`, so we can now make the `project` parameter optional, and an accurate fallback value can be provided.

2. For the `project_url` parameter, it is expected that the URL would be in the format `https://console.platform.sh/<project_owner_name>/<project_id>`. I assume this parameter was exposed because the project_owner_name is not provided in the payload. However, I discovered that the Platform.sh web admin console is smart enough to reroute project URLs to the correct final URL, so that `https://console.platform.sh/project/<project_id>`  will automatically redirect to `https://console.platform.sh/<project_owner_name>/<project_id>`.  This means that technically, we can now provide a smart and working fallback URL, and therefore the `project_url` parameter is no longer required. I've left the parameter in place for backward compatibility.