### PR TITLE
HTTP Foundation require updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "type": "project",
     "require": {
         "maknz/slack": "^1.7",
-        "symfony/http-foundation": "^2 || ^3 || ^4"
+        "symfony/http-foundation": "^2 || ^3 || ^4 || ^6 || ^7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
 Problem 1
    - Root composer.json requires hanoii/platformsh2slack 1.9 -> satisfiable by hanoii/platformsh2slack[1.9].
    - hanoii/platformsh2slack 1.9 requires symfony/http-foundation ^2 || ^3 || ^4 -> found symfony/http-foundation[2.0.4, ..., 2.8.x-dev, v3.0.0-BETA1, ..., 3.4.x-dev, v4.0.0-BETA1, ..., 4.4.x-dev] but the package is fixed to v6.4.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

